### PR TITLE
Add interactive map of Central London subdistricts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# Central_London_Submarkets
+# Central London Submarkets
+
+Open `index.html` in a web browser to explore the interactive map of company subdistricts. Hover over an area to view its label.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Central London Submarkets</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+oUXEY5JCC0t1zu3rJ6mkhX1scohd50B8ZTMn90oE=" crossorigin=""/>
+  <style>
+    #map { height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j8e+T1M3PoeEYmngEjj6bBdgiyE4Z0AQCA0yZzM=" crossorigin=""></script>
+  <script>
+    var map = L.map('map').setView([51.5074, -0.1278], 11);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '© OpenStreetMap'
+    }).addTo(map);
+
+    function style(feature) {
+      return {
+        fillColor: '#cccccc',
+        weight: 1,
+        color: '#555555',
+        fillOpacity: 0.7
+      };
+    }
+
+    function highlightFeature(e) {
+      e.target.setStyle({
+        fillColor: '#666666'
+      });
+      e.target.openPopup();
+    }
+
+    function resetHighlight(e) {
+      geojson.resetStyle(e.target);
+      e.target.closePopup();
+    }
+
+    function onEachFeature(feature, layer) {
+      if (feature.properties && feature.properties.label) {
+        layer.bindPopup(feature.properties.label);
+      }
+      layer.on({
+        mouseover: highlightFeature,
+        mouseout: resetHighlight
+      });
+    }
+
+    var geojson;
+    fetch('final_poly.geojson')
+      .then(function(response) { return response.json(); })
+      .then(function(data) {
+        geojson = L.geoJSON(data, {
+          style: style,
+          onEachFeature: onEachFeature
+        }).addTo(map);
+        map.fitBounds(geojson.getBounds());
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Leaflet-based landing page displaying company subdistricts from `final_poly.geojson`
- Implement hover popups and grey highlight styling for map areas
- Document how to view the interactive map

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895ba70f4808332b5c7ad2826799c7b