### PR TITLE
Add fallback for GeoJSON loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Central London Submarkets
 
-Open `index.html` in a web browser to explore the interactive map of company subdistricts. Hover over an area to view its label.
+Open `index.html` in a web browser to explore the interactive map of company subdistricts. Hover over an area to view its label. The map first tries to load the GeoJSON file locally and, if that fails, falls back to the copy hosted on GitHub.
 

--- a/index.html
+++ b/index.html
@@ -54,12 +54,23 @@
     }
 
     var geojson;
-    fetch('./final_poly.geojson')
+    var localUrl = 'final_poly.geojson';
+    var remoteUrl = 'https://raw.githubusercontent.com/CharlieCoughlin1/Central_London_Submarkets/main/final_poly.geojson';
+
+    fetch(localUrl)
       .then(function(response) {
         if (!response.ok) {
           throw new Error('Network response was not ok');
         }
         return response.json();
+      })
+      .catch(function() {
+        return fetch(remoteUrl).then(function(response) {
+          if (!response.ok) {
+            throw new Error('Network response was not ok');
+          }
+          return response.json();
+        });
       })
       .then(function(data) {
         geojson = L.geoJSON(data, {


### PR DESCRIPTION
## Summary
- fallback to GitHub-hosted GeoJSON if local file can't be fetched
- document how GeoJSON loads in README

## Testing
- `python -m json.tool final_poly.geojson | head -n 20`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895beec80a48332ba5231c01c73c07b