### PR TITLE
Ensure map resources load and polygons display in grey

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Central London Submarkets</title>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+oUXEY5JCC0t1zu3rJ6mkhX1scohd50B8ZTMn90oE=" crossorigin=""/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <style>
     body, html { margin: 0; }
     h1 { text-align: center; margin: 10px 0; }
@@ -13,7 +13,7 @@
 <body>
   <h1>Central London Submarkets</h1>
   <div id="map"></div>
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j8e+T1M3PoeEYmngEjj6bBdgiyE4Z0AQCA0yZzM=" crossorigin=""></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script>
     var map = L.map('map').setView([51.5074, -0.1278], 11);
 


### PR DESCRIPTION
## Summary
- Load Leaflet CSS/JS without integrity attributes to fix blank map
- Keep polygon style with grey fill and hover highlight

## Testing
- `python -m json.tool final_poly.geojson >/tmp/out.json`


------
https://chatgpt.com/codex/tasks/task_e_6895c298e68883329204cec5c2608c7a