### PR TITLE
Remove base map and disable interactivity

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <style>
     body, html { margin: 0; }
     h1 { text-align: center; margin: 10px 0; }
-    #map { height: calc(100vh - 60px); }
+    #map { height: calc(100vh - 60px); background: #ffffff; }
   </style>
 </head>
 <body>
@@ -15,12 +15,15 @@
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script>
-    var map = L.map('map').setView([51.5074, -0.1278], 11);
-
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 19,
-      attribution: '© OpenStreetMap'
-    }).addTo(map);
+    var map = L.map('map', {
+      zoomControl: false,
+      dragging: false,
+      scrollWheelZoom: false,
+      doubleClickZoom: false,
+      boxZoom: false,
+      keyboard: false,
+      touchZoom: false
+    }).setView([51.5074, -0.1278], 11);
 
     function style(feature) {
       return {


### PR DESCRIPTION
## Summary
- Remove OpenStreetMap tile layer from Leaflet map
- Disable zooming, panning, and other interactive controls for a static display
- Set a white background for the map container to highlight shapefile outlines

## Testing
- `xmllint --noout index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895ccefb9308332bde829226e643cb3