### PR TITLE
Bust cache for GeoJSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,8 +57,9 @@
     }
 
     var geojson;
-    var localUrl = 'final_poly.geojson';
-    var remoteUrl = 'https://raw.githubusercontent.com/CharlieCoughlin1/Central_London_Submarkets/main/final_poly.geojson';
+    var cacheBuster = '?v=' + Date.now();
+    var localUrl = 'final_poly.geojson' + cacheBuster;
+    var remoteUrl = 'https://raw.githubusercontent.com/CharlieCoughlin1/Central_London_Submarkets/main/final_poly.geojson' + cacheBuster;
 
     fetch(localUrl)
       .then(function(response) {


### PR DESCRIPTION
## Summary
- Add cache-busting query parameter to local and remote GeoJSON URLs so the map loads the latest shapefile.

## Testing
- `python -m json.tool final_poly.geojson >/tmp/final_poly.json 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_6895ce42b7d08332a01c20aade578ab5