### PR TITLE
Improve map popups and styling for landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,28 +6,43 @@
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/din-pro" />
   <style>
-    body, html { margin: 0; }
+    body, html {
+      margin: 0;
+      font-family: 'DIN Pro', sans-serif;
+    }
     h1 {
       text-align: center;
-      margin: 10px 0;
+      margin: 20px 0 10px;
       font-family: 'DIN Pro', sans-serif;
       color: #cc2030;
+      font-size: 2.5em;
+      font-weight: 700;
+      letter-spacing: 1px;
+      border-bottom: 2px solid #cc2030;
+      display: inline-block;
+      margin-left: auto;
+      margin-right: auto;
+      padding-bottom: 5px;
     }
     #map { height: calc(100vh - 60px); background: #ffffff; }
     .custom-popup .leaflet-popup-content-wrapper {
       background: #ffffff;
       border: 2px solid #cc2030;
       border-radius: 4px;
+      min-width: 180px;
+      padding: 12px 18px;
     }
     .custom-popup .leaflet-popup-tip {
       background: #ffffff;
       border: 2px solid #cc2030;
     }
     .custom-popup .leaflet-popup-content {
-      margin: 8px 10px;
+      margin: 0;
       font-family: 'DIN Pro', sans-serif;
       font-weight: bold;
       color: #cc2030;
+      font-size: 1.1rem;
+      text-align: center;
     }
   </style>
 </head>
@@ -49,7 +64,7 @@
     function style(feature) {
       if (feature.properties && feature.properties.id === 'layer-0') {
         return {
-          fillColor: '#87CEEB',
+          fillColor: '#ADD8E6',
           weight: 0,
           color: 'transparent',
           stroke: false,
@@ -66,26 +81,28 @@
 
     function highlightFeature(e) {
       var layer = e.target;
-      var isRiver = layer.feature.properties.id === 'layer-0';
-      layer.setStyle({
-        fillColor: isRiver ? '#87CEEB' : '#cc2030'
-      });
-      layer.openPopup();
+      layer.setStyle({ fillColor: '#cc2030' });
+      if (layer.getPopup()) {
+        layer.openPopup();
+      }
     }
 
     function resetHighlight(e) {
       geojson.resetStyle(e.target);
-      e.target.closePopup();
+      if (e.target.getPopup()) {
+        e.target.closePopup();
+      }
     }
 
     function onEachFeature(feature, layer) {
-      if (feature.properties && feature.properties.label) {
-        layer.bindPopup(feature.properties.label, { className: 'custom-popup' });
+      var isRiver = feature.properties && feature.properties.id === 'layer-0';
+      if (!isRiver && feature.properties && feature.properties.label) {
+        layer.bindPopup(feature.properties.label, { className: 'custom-popup', closeButton: false });
+        layer.on({
+          mouseover: highlightFeature,
+          mouseout: resetHighlight
+        });
       }
-      layer.on({
-        mouseover: highlightFeature,
-        mouseout: resetHighlight
-      });
     }
 
     var geojson;


### PR DESCRIPTION
## Summary
- Restyle landing page title using DIN Pro for a cleaner look
- Enlarge map popups, remove close buttons, and prevent river feature popups
- Render River Thames in light blue with no interaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895fe55410c8332aeaaf605cbc348df