### PR TITLE
Refine river styling and popup interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,15 @@
       padding-bottom: 5px;
     }
     #map { height: calc(100vh - 60px); background: #ffffff; }
+    .custom-popup {
+      pointer-events: none;
+    }
     .custom-popup .leaflet-popup-content-wrapper {
       background: #ffffff;
       border: 2px solid #cc2030;
       border-radius: 4px;
-      min-width: 180px;
-      padding: 12px 18px;
+      min-width: 200px;
+      padding: 14px 20px;
     }
     .custom-popup .leaflet-popup-tip {
       background: #ffffff;
@@ -65,11 +68,10 @@
       if (feature.properties && feature.properties.label === 'River Thames') {
         return {
           fillColor: '#ADD8E6',
-          weight: 0,
-          color: 'transparent',
-          stroke: false,
+          weight: 1,
+          color: '#555555',
           fillOpacity: 0.7,
-          interactive: false
+          stroke: true
         };
       }
       return {


### PR DESCRIPTION
## Summary
- Add subtle black outline to River Thames for consistent styling
- Enlarge and stabilize map popups with pointer-event fixes and wider layout

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689602c47e548332aca5f4cb7d3766e0