### PR TITLE
Enlarge map popups and center title

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,17 +16,15 @@
       }
       h1 {
         text-align: center;
-        margin: 20px 0 10px;
+        margin: 20px auto 10px;
         font-family: "DIN Pro", sans-serif;
         color: #cc2030;
-        font-size: 2.5em;
+        font-size: 4em;
         font-weight: 700;
         letter-spacing: 1px;
         border-bottom: 2px solid #cc2030;
-        display: inline-block;
-        margin-left: auto;
-        margin-right: auto;
         padding-bottom: 5px;
+        width: fit-content;
       }
       #map {
         height: calc(100vh - 60px);
@@ -39,20 +37,20 @@
         background: #ffffff;
         border: 2px solid #cc2030;
         border-radius: 8px;
-        min-width: 260px;
-        padding: 20px 25px;
+        min-width: 400px;
+        padding: 35px 45px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
       }
-      .custom-popup .leaflet-popup-tip {
-        background: #ffffff;
-        border: 2px solid #cc2030;
+      .custom-popup .leaflet-popup-tip,
+      .custom-popup .leaflet-popup-tip-container {
+        display: none;
       }
       .custom-popup .leaflet-popup-content {
         margin: 0;
         font-family: "DIN Pro", sans-serif;
         font-weight: bold;
         color: #cc2030;
-        font-size: 1.3rem;
+        font-size: 2rem;
         text-align: center;
       }
     </style>


### PR DESCRIPTION
## Summary
- enlarge map popups and remove pointer
- center title above map and increase size with DIN Pro font

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1edfe848332a870069c8fab9bdb