### PR TITLE
Center map popups and apply DIN Pro font sitewide

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,9 @@
     />
     <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/din-pro" />
     <style>
+      html,
       body,
-      html {
+      .leaflet-container {
         margin: 0;
         font-family: "DIN Pro", sans-serif;
       }
@@ -40,6 +41,9 @@
         min-width: 400px;
         padding: 35px 45px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
       .custom-popup .leaflet-popup-tip,
       .custom-popup .leaflet-popup-tip-container {
@@ -52,6 +56,7 @@
         color: #cc2030;
         font-size: 2rem;
         text-align: center;
+        width: 100%;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- Center popup content using flexbox for consistent submarket labels
- Apply DIN Pro font across document and Leaflet map elements

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f404afac8332a9a946ec900ceb92