### PR TITLE
Ensure popout labels never clip outside boundaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,9 @@
         padding: 35px 45px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
         display: inline-block;
-        width: auto;
+        width: max-content;
         max-width: none;
+        box-sizing: border-box;
       }
       .custom-popup .leaflet-popup-tip,
       .custom-popup .leaflet-popup-tip-container {
@@ -126,6 +127,7 @@
           layer.bindPopup(feature.properties.label, {
             className: "custom-popup",
             closeButton: false,
+            maxWidth: 1000,
           });
           layer.on({
             mouseover: highlightFeature,


### PR DESCRIPTION
## Summary
- Expand custom Leaflet popup width using `max-content` and `box-sizing` to accommodate long subdistrict labels
- Increase popup `maxWidth` to avoid clipping text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899fa4f42ac8332b3692831b73789dc