### PR TITLE
Remove polygon outlines and refine popup styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@
       }
       h1 {
         text-align: center;
-        margin: 10px auto 0;
+        margin: 8px auto 0;
         font-family: "DIN Pro", "DINPro", sans-serif;
         color: #cc2030;
-        font-size: 3em;
+        font-size: 2em;
         font-weight: 700;
         letter-spacing: 1px;
         text-transform: uppercase;
@@ -29,14 +29,14 @@
 
       .subtitle {
         text-align: center;
-        margin: 5px auto 15px;
+        margin: 4px auto 12px;
         font-family: "DIN Pro", "DINPro", sans-serif;
         color: #cc2030;
-        font-size: 1.2em;
+        font-size: 1em;
         font-weight: 400;
       }
       #map {
-        height: calc(100vh - 60px);
+        height: calc(100vh - 50px);
         background: #ffffff;
         position: relative;
       }
@@ -47,7 +47,7 @@
         background: #ffffff;
         border: 1px solid #cc2030;
         border-radius: 8px;
-        padding: 20px 25px;
+        padding: 12px 16px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
         display: inline-block;
         width: max-content;
@@ -66,39 +66,39 @@
       }
       .custom-popup .popup-title {
         color: #cc2030;
-        font-size: 1.75rem;
+        font-size: 1.25rem;
         font-weight: 700;
       }
       .custom-popup .popup-prices {
-        margin-top: 10px;
+        margin-top: 8px;
         display: flex;
         justify-content: center;
-        gap: 10px;
+        gap: 8px;
       }
       .price-box {
         border: 1px solid #cc2030;
         border-radius: 6px;
-        padding: 8px 16px;
+        padding: 6px 10px;
         background: #f9f9f9;
-        min-width: 100px;
+        min-width: 80px;
       }
       .price-box .grade {
         display: block;
         color: #cc2030;
-        font-size: 1rem;
+        font-size: 0.9rem;
         font-weight: 700;
       }
       .price-box .price {
         display: block;
         color: #000000;
-        font-size: 1.2rem;
+        font-size: 1rem;
         font-weight: 500;
       }
       .psf-control {
         background: rgba(255, 255, 255, 0.8);
         border-radius: 4px;
         padding: 2px 6px;
-        font-size: 0.8rem;
+        font-size: 0.7rem;
         font-family: "DIN Pro", "DINPro", sans-serif;
         margin: 0 4px 4px 0;
       }
@@ -156,23 +156,20 @@
         if (feature.properties && feature.properties.label === "River Thames") {
           return {
             fillColor: "#ADD8E6",
-            weight: 0.75,
-            color: "#555555",
             fillOpacity: 0.7,
-            stroke: true,
+            stroke: false,
           };
         }
         return {
           fillColor: "#cccccc",
-          weight: 0.75,
-          color: "#555555",
           fillOpacity: 0.7,
+          stroke: false,
         };
       }
 
       function highlightFeature(e) {
         var layer = e.target;
-        layer.setStyle({ fillColor: "#cc2030", weight: 1.5 });
+        layer.setStyle({ fillColor: "#cc2030", color: "#cc2030", weight: 1.5 });
         if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
           layer.bringToFront();
         }
@@ -212,7 +209,7 @@
           layer.bindPopup(content, {
             className: "custom-popup",
             closeButton: false,
-            maxWidth: 1000,
+            maxWidth: 300,
           });
           layer.on({
             mouseover: highlightFeature,


### PR DESCRIPTION
## Summary
- Drop default polygon borders so only hovered submarkets are outlined.
- Shrink map title, subtitles, and popup boxes for a cleaner layout.
- Tighten popup layout and limit width for more user-friendly display.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Central_London_Submarkets/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68af22d76934832f8086b8007a7f14c8