### PR TITLE
Refine map popups and hover behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,32 +71,32 @@
         color:var(--muted-ink);
       }
       .custom-popup{pointer-events:none;}
-      .custom-popup *{user-select:none;}
+      .custom-popup *{pointer-events:none;user-select:none;}
       .custom-popup .maplibregl-popup-tip{display:none;}
       .custom-popup .maplibregl-popup-content{
         background:rgba(255,255,255,.6);
         border:1px solid var(--stroke);
         border-radius:var(--radius-2);
         box-shadow:var(--shadow-1);
-        padding:8px 12px;
+        padding:6px 10px;
         margin:0;
         text-align:center;
         box-sizing:border-box;
         white-space:normal;
         overflow-wrap:anywhere;
         word-break:break-word;
-        max-width:min(90vw, 420px);
+        max-width:min(90vw, 360px);
         font-family:"DIN Pro","DINPro",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
         font-variant-numeric:tabular-nums;
       }
-      .popup-title{color:var(--brand);font-weight:700;font-size:1.05rem;letter-spacing:.2px;display:block;line-height:1.2;margin:0;padding:0 2px;text-transform:uppercase;}
+      .popup-title{color:var(--brand);font-weight:700;font-size:1rem;letter-spacing:.2px;display:block;line-height:1.2;margin:0;padding:0 2px;text-transform:uppercase;}
       .popup-prices{margin-top:8px;display:flex;justify-content:center;gap:8px;}
       .price-box{
         border:1px solid var(--stroke);
         background:#FAFAFB;
         border-radius:var(--radius-1);
-        padding:4px 8px;
-        min-width:86px;
+        padding:4px 6px;
+        min-width:80px;
         line-height:1.2;
         font-variant-numeric:tabular-nums;
       }
@@ -105,8 +105,8 @@
       @media (max-width:480px){
         .site-header{padding:10px 12px 4px;}
         h1{font-size:1.6rem;}
-        .popup-title{font-size:.95rem;}
-        .price-box{min-width:74px;padding:4px 6px;}
+        .popup-title{font-size:.9rem;}
+        .price-box{min-width:68px;padding:4px 5px;}
       }
       @media (prefers-reduced-motion: reduce){
         *{transition:none!important;}
@@ -172,7 +172,8 @@
       map.once('load', () => map.resize());
 
       let hoveredId = null;
-      const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false, className: 'custom-popup', maxWidth: '420px' });
+      const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false, className: 'custom-popup', maxWidth: '360px' });
+      popup.on('open', () => popup.getElement().style.pointerEvents = 'none');
       let popupTimer = null;
 
       const brand = getComputedStyle(document.documentElement).getPropertyValue('--brand').trim();
@@ -299,7 +300,7 @@
                 bounds.extend([coords[i], coords[i + 1]]);
               }
             });
-            map.fitBounds(bounds, { padding: 20 });
+            map.fitBounds(bounds, { padding: { top: 10, right: 20, bottom: 20, left: 20 } });
 
             function handleMove(e) {
               const features = map.queryRenderedFeatures(e.point, { layers: ['subdistrict-fills'] });


### PR DESCRIPTION
## Summary
- Shrink map popups and price boxes for a more compact display
- Allow hovering submarkets beneath open popups by disabling popup pointer events
- Shift map view upward to reduce gap above Camden

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b02b77326c832f9f77bf34e082d202