### PR TITLE
Refine map popout design for Central London submarkets

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         --radius-1:6px;
         --radius-2:8px;
         --shadow-1:0 4px 12px rgba(0,0,0,.12);
+        --popup-accent: var(--brand);
       }
 
       html, body {
@@ -70,44 +71,77 @@
         font-size:.7rem;
         color:var(--muted-ink);
       }
-      .custom-popup{pointer-events:none;opacity:0;transition:opacity .2s ease-in-out;}
-      .custom-popup.active{opacity:1;}
+      .custom-popup{pointer-events:none; opacity:0; transform:translateY(2px); transition:opacity .16s ease, transform .16s ease;}
+      .custom-popup.active{opacity:1; transform:translateY(0);}
       .custom-popup *{pointer-events:none;user-select:none;}
-      .custom-popup .maplibregl-popup-tip{display:none;}
       .custom-popup .maplibregl-popup-content{
-        background:rgba(255,255,255,.6);
+        background:rgba(255,255,255,.85);
         border:1px solid var(--stroke);
-        border-radius:var(--radius-2);
+        border-radius:10px;
         box-shadow:var(--shadow-1);
-        padding:6px 10px;
+        padding:10px 12px 12px;
         margin:0;
         text-align:center;
         box-sizing:border-box;
         white-space:normal;
         overflow-wrap:anywhere;
         word-break:break-word;
-        max-width:min(90vw, 360px);
+        max-width:min(90vw, 340px);
         font-family:"DIN Pro","DINPro",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
         font-variant-numeric:tabular-nums;
+        position:relative;
       }
-      .popup-title{color:var(--brand);font-weight:700;font-size:1rem;letter-spacing:.2px;display:block;line-height:1.2;margin:0;padding:0 2px;text-transform:uppercase;}
-      .popup-prices{margin-top:8px;display:flex;justify-content:center;gap:8px;}
+      /* thin brand accent bar */
+      .custom-popup .maplibregl-popup-content::before{
+        content:"";
+        position:absolute;
+        top:0; left:0; right:0;
+        height:3px;
+        background:var(--popup-accent);
+        border-top-left-radius:10px;
+        border-top-right-radius:10px;
+      }
+      .custom-popup .maplibregl-popup-tip{display:none;}
+      .pop-inner{opacity:1; transform:translateY(0); transition:opacity .14s ease, transform .14s ease;}
+      .pop-inner.is-out{opacity:0; transform:translateY(4px);}
+      .pop-inner.is-in{opacity:1; transform:translateY(0);}
+      .popup-title-row{
+        display:flex; align-items:center; justify-content:center; gap:8px;
+        margin:2px 0 4px;
+      }
+      .popup-badge{
+        width:8px; height:8px; border-radius:50%; background:var(--popup-accent); flex:0 0 8px;
+      }
+      .popup-title{
+        color:var(--ink);
+        font-weight:700; font-size:1rem; letter-spacing:.3px;
+        line-height:1.2; margin:0; padding:0 2px;
+        text-transform:uppercase;
+      }
+      .popup-prices{
+        margin-top:6px;
+        display:flex; justify-content:center; gap:8px; flex-wrap:wrap;
+      }
       .price-box{
         border:1px solid var(--stroke);
         background:#FAFAFB;
-        border-radius:var(--radius-1);
-        padding:4px 6px;
-        min-width:80px;
+        border-radius:8px;
+        padding:6px 8px;
+        min-width:84px;
         line-height:1.2;
-        font-variant-numeric:tabular-nums;
       }
-      .price-box .grade{display:block;color:var(--muted-ink);font-size:.9rem;font-weight:700;}
-      .price-box .price{display:block;color:var(--ink);font-size:1rem;font-weight:500;}
+      .price-box .grade{
+        display:block; color:var(--muted-ink); font-size:.85rem; font-weight:700; letter-spacing:.2px;
+      }
+      .price-box .price{
+        display:block; color:var(--ink); font-size:1rem; font-weight:600;
+      }
       @media (max-width:480px){
         .site-header{padding:10px 12px 0;}
         h1{font-size:1.6rem;}
-        .popup-title{font-size:.9rem;}
-        .price-box{min-width:68px;padding:4px 5px;}
+        .custom-popup .maplibregl-popup-content{max-width:calc(100vw - 24px); padding:8px 10px 10px;}
+        .popup-title{font-size:.92rem;}
+        .price-box{min-width:76px; padding:6px 7px;}
       }
       @media (prefers-reduced-motion: reduce){
         *{transition:none!important;}
@@ -174,7 +208,7 @@
       map.once('load', () => map.resize());
 
       let hoveredId = null;
-      const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false, className: 'custom-popup', maxWidth: '360px' });
+      const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false, className: 'custom-popup', maxWidth: '340px' });
       popup.on('open', () => popup.getElement().style.pointerEvents = 'none');
       let popupTimer = null;
       let hoverLeaveTimer = null;
@@ -200,15 +234,21 @@
         return [(minX + maxX) / 2, (minY + maxY) / 2];
       }
 
-      function renderPopup(label, dataInfo) {
-        if (!dataInfo) return "<div class='popup-title'>" + label.toUpperCase() + "</div>";
-        return (
-          "<div class='popup-title'>" + label.toUpperCase() + "</div>" +
-          "<div class='popup-prices'>" +
-            "<div class='price-box'><span class='grade'>Grade A</span><span class='price'>" + dataInfo.A + "</span></div>" +
-            "<div class='price-box'><span class='grade'>Grade B</span><span class='price'>" + dataInfo.B + "</span></div>" +
-          "</div>"
-        );
+      function renderPopup(label, dataInfo){
+        const title = (label || '').toUpperCase();
+        const prices = dataInfo ? `
+    <div class="popup-prices">
+      <div class="price-box"><span class="grade">Grade A</span><span class="price">${dataInfo.A}</span></div>
+      <div class="price-box"><span class="grade">Grade B</span><span class="price">${dataInfo.B}</span></div>
+    </div>` : '';
+        return `
+    <div class="pop-inner" data-label="${title}" role="status" aria-live="polite">
+      <div class="popup-title-row">
+        <span class="popup-badge" aria-hidden="true"></span>
+        <h3 class="popup-title">${title}</h3>
+      </div>
+      ${prices}
+    </div>`;
       }
 
       function removeHover() {
@@ -222,22 +262,46 @@
       }
 
       function showPopup(center, label) {
-        popup.setLngLat(center).setHTML(renderPopup(label, priceData[label]));
+        const nextHtml = renderPopup(label, priceData[label]);
+        const isOpen = popup.isOpen();
         clearTimeout(popupFadeTimer);
-        if (!popup.isOpen()) {
-          popup.addTo(map);
+
+        // Open if closed
+        if (!isOpen) {
+          popup.setLngLat(center).setHTML(nextHtml).addTo(map);
           requestAnimationFrame(() => popup.getElement().classList.add('active'));
-        } else {
-          popup.getElement().classList.add('active');
+          return;
         }
+
+        // If open and same label: only move location; keep content
+        const current = popup.getElement().querySelector('.pop-inner');
+        const currentLabel = current ? current.getAttribute('data-label') : '';
+        const nextLabel = (label || '').toUpperCase();
+
+        if (currentLabel === nextLabel) {
+          popup.setLngLat(center);
+          return;
+        }
+
+        // Cross-fade content swap
+        if (current) current.classList.add('is-out');
+        setTimeout(() => {
+          popup.setLngLat(center).setHTML(nextHtml);
+          const fresh = popup.getElement().querySelector('.pop-inner');
+          fresh.classList.add('is-out');
+          requestAnimationFrame(() => {
+            fresh.classList.remove('is-out');
+            fresh.classList.add('is-in');
+          });
+        }, 130);
       }
 
-      function hidePopup() {
+      function hidePopup(){
         if (!popup.isOpen()) return;
         const el = popup.getElement();
         el.classList.remove('active');
         clearTimeout(popupFadeTimer);
-        popupFadeTimer = setTimeout(() => popup.remove(), 200);
+        popupFadeTimer = setTimeout(() => popup.remove(), 180);
       }
 
       function scheduleClearHover() {


### PR DESCRIPTION
## Summary
- Restyle map popouts with glassy card, brand accent bar and badge
- Add cross-fade content transitions and smooth open/close animations
- Improve accessibility with role status and maintain DIN Pro typography

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0335c8368832fb9d9fd5b4d0012a2