### PR TITLE
Tidy map popup sizing and Thames outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,13 +77,7 @@
         color:var(--muted-ink);
         z-index:1;
       }
-      .reset-view{right:8px;}
-      .legend-chip{left:8px;display:flex;align-items:center;gap:4px;}
-      .legend-chip button{
-        background:none;border:none;padding:0;margin:0;font-size:.7rem;color:var(--muted-ink);cursor:pointer;
-      }
-      .legend-chip .legend-text{display:none;}
-      .legend-chip.active .legend-text{display:inline;}
+      .legend-chip{left:8px;}
       .psf-control{
         position:absolute;
         bottom:8px;
@@ -103,14 +97,14 @@
         border:1px solid var(--stroke);
         border-radius:10px;
         box-shadow:var(--shadow-1);
-        padding:10px 12px 12px;
+        padding:8px 10px 10px;
         margin:0;
         text-align:center;
         box-sizing:border-box;
         white-space:normal;
         overflow-wrap:anywhere;
         word-break:break-word;
-        max-width:min(90vw, 340px);
+        max-width:min(90vw, 260px);
         font-family:"DIN Pro","DINPro",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
         font-variant-numeric:tabular-nums;
         position:relative;
@@ -147,8 +141,8 @@
         border:1px solid var(--stroke);
         background:#FAFAFB;
         border-radius:8px;
-        padding:6px 8px;
-        min-width:84px;
+        padding:4px 6px;
+        min-width:72px;
         line-height:1.2;
       }
       .price-box .grade{
@@ -160,10 +154,9 @@
       @media (max-width:480px){
         .site-header{padding:10px 12px 0;}
         h1{font-size:1.6rem;}
-        .custom-popup .maplibregl-popup-content{max-width:calc(100vw - 24px); padding:8px 10px 10px;}
+        .custom-popup .maplibregl-popup-content{max-width:calc(100vw - 24px); padding:6px 8px 8px;}
         .popup-title{font-size:.92rem;}
-        .price-box{min-width:76px; padding:6px 7px;}
-        .reset-view{display:none;}
+        .price-box{min-width:65px; padding:4px 6px;}
       }
       @media (prefers-reduced-motion: reduce){
         *{transition:none!important;}
@@ -176,8 +169,7 @@
       <p class="subtitle">Click a subdistrict to get started</p>
     </header>
     <div id="map">
-      <div class="map-chip legend-chip"><button class="legend-toggle" aria-label="Toggle legend">?</button><span class="legend-text">Submarket (grey) • Hover (red outline) • River (blue)</span></div>
-      <button class="map-chip reset-view" id="reset-view">Reset view</button>
+      <div class="map-chip legend-chip"><span class="legend-text">Submarket (grey) • Hover (red outline) • River (blue)</span></div>
       <div class="psf-control">*All prices are per sq ft</div>
     </div>
     <script src="https://unpkg.com/maplibre-gl@3.3.1/dist/maplibre-gl.js"></script>
@@ -212,8 +204,6 @@
 
       const root = document.documentElement;
       const headerEl = document.querySelector('.site-header');
-      const legendChip = document.querySelector('.legend-chip');
-      legendChip.querySelector('.legend-toggle').addEventListener('click', () => legendChip.classList.toggle('active'));
 
       const map = new maplibregl.Map({
         container: 'map',
@@ -255,7 +245,7 @@
       map.once('load', () => map.resize());
 
       let hoveredId = null;
-      const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false, className: 'custom-popup', maxWidth: '340px' });
+      const popup = new maplibregl.Popup({ closeButton: false, closeOnClick: false, className: 'custom-popup', maxWidth: '260px' });
       popup.on('open', () => popup.getElement().style.pointerEvents = 'none');
       let popupTimer = null;
       let hoverLeaveTimer = null;
@@ -263,6 +253,7 @@
 
       const brand = getComputedStyle(document.documentElement).getPropertyValue('--brand').trim();
       const water = getComputedStyle(document.documentElement).getPropertyValue('--water').trim();
+      const waterStroke = getComputedStyle(document.documentElement).getPropertyValue('--water-stroke').trim();
 
       function setHover(id, isHovering) {
         map.setFeatureState({ source: 'subdistricts', id }, { hover: isHovering });
@@ -395,6 +386,20 @@
             });
 
             map.addLayer({
+              id: 'thames-outline',
+              type: 'line',
+              source: 'subdistricts',
+              filter: ['==', ['get', 'label'], 'River Thames'],
+              paint: {
+                'line-color': waterStroke,
+                'line-width': 1.2,
+                'line-join': 'round',
+                'line-cap': 'round',
+                'line-smooth': 0.6
+              }
+            });
+
+            map.addLayer({
               id: 'subdistrict-fills',
               type: 'fill',
               source: 'subdistricts',
@@ -448,12 +453,6 @@
             });
             map.fitBounds(bounds, { padding: { top: 10, right: 20, bottom: 20, left: 20 } });
 
-            const resetBtn = document.getElementById('reset-view');
-            if (resetBtn) {
-              resetBtn.addEventListener('click', () => {
-                map.fitBounds(bounds, { padding: { top: 10, right: 20, bottom: 20, left: 20 } });
-              });
-            }
 
             function handleMove(e) {
               const features = map.queryRenderedFeatures(e.point, { layers: ['subdistrict-fills'] });


### PR DESCRIPTION
## Summary
- Shrink hover popups and pricing boxes for a tighter layout
- Add smoothed outline for the River Thames polygon using a dedicated line layer
- Remove reset view and legend toggle buttons from the map UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0583d9070832fbdc75fdc151eb68c