### PR TITLE
Fix map position under header

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,14 +31,16 @@
       }
       body {
         margin:0;
-        display:grid;
-        grid-template-rows:auto 1fr;
+        display:block;
         background:var(--surface);
         color:var(--ink);
         font-family:"DIN Pro","DINPro",system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+        padding-top:var(--header-h);
       }
       .site-header{
-        position:sticky;top:0;z-index:2;
+        position:fixed;
+        top:0; left:0; right:0;
+        z-index:10;
         background:var(--surface);
         border-bottom:1px solid var(--stroke);
         box-shadow:0 1px 2px rgba(0,0,0,.04);
@@ -60,10 +62,8 @@
       #map{
         height:calc(var(--vh) - var(--header-h));
         min-height:320px;
-        flex:0 0 auto;
         position:relative;
         background:var(--ui);
-        border-top:1px solid var(--stroke);
         padding-bottom:env(safe-area-inset-bottom);
       }
       .psf-control{
@@ -214,16 +214,27 @@
       new ResizeObserver(() => map.resize()).observe(mapContainer);
 
       function setVH(){
-        root.style.setProperty('--vh', window.innerHeight + 'px');
+        const vv = window.visualViewport;
+        const h = vv ? Math.round(vv.height) : window.innerHeight;
+        root.style.setProperty('--vh', h + 'px');
         map.resize();
       }
       setVH();
+
+      if (window.visualViewport) {
+        visualViewport.addEventListener('resize', setVH);
+        visualViewport.addEventListener('scroll', setVH);
+      }
       window.addEventListener('resize', setVH);
       window.addEventListener('orientationchange', setVH);
 
-      function updateHeaderHeight(){
-        const h = headerEl.getBoundingClientRect().height;
+      async function updateHeaderHeight(){
+        if (document.fonts && document.fonts.ready) {
+          try { await document.fonts.ready; } catch(e){}
+        }
+        const h = Math.ceil(headerEl.getBoundingClientRect().height);
         root.style.setProperty('--header-h', h + 'px');
+        document.body.style.paddingTop = h + 'px';
         map.resize();
       }
       updateHeaderHeight();


### PR DESCRIPTION
## Summary
- Switch header to fixed and adjust body layout to reserve header height so the map sits directly below.
- Remove map's top border and update viewport height calculations using `visualViewport` for dynamic resizing.
- Measure header height after fonts load and push body content accordingly to keep layout consistent across devices.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b05d024e8c832f9d83a91b02dad9e7