### PR TITLE
Increase map width by 50% and center expanded viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,10 +228,11 @@
       #map{
         position:sticky;
         top:0;
-        left:0;
-        right:0;
-        width:100%;
+        left:50%;
+        right:auto;
+        width:150%;
         margin-left:0;
+        transform:translateX(-50%);
         height:var(--map-height);
         min-height:858px;
         background:#fff;


### PR DESCRIPTION
### Motivation
- The previous sizing update did not produce a visually wider map because the container remained anchored to both left and right edges, preventing an increased effective width.
- The intent is to make the map more prominent by increasing its viewport width while keeping it visually centered in the page.

### Description
- Updated `#map` CSS to `width: 150%` so the map container is rendered 50% wider than the viewport.
- Replaced the right-edge anchoring by setting `left: 50%` and `right: auto` so the enlarged width can take effect.
- Applied `transform: translateX(-50%)` to horizontally center the expanded map within the viewport.

### Testing
- Served the site locally with `python3 -m http.server 4173` and confirmed the page loaded successfully.
- Ran a Playwright validation script to open `http://127.0.0.1:4173/index.html` and capture `artifacts/map-width-150.png`, and the screenshot was produced successfully indicating the wider map rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69affdeb6094832f81d2736af464a10a)