### PR TITLE
Refresh recent Central London office headline events for 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -1372,9 +1372,9 @@
             <div class="stat-card">
               <h3><span class="live-dot" aria-hidden="true"></span>RECENT HEADLINE EVENTS</h3>
               <div class="headline-rotator" id="headline-rotator" aria-live="polite">
-                <small class="stat-subtext" id="headline-description">Visa relocating European headquarters to Canary Wharf, leasing</small>
-                <span class="stat-value" id="headline-size">300,000 sq ft</span>
-                <small class="stat-subtext" id="headline-building">at <strong>One Canada Square, E14</strong></small>
+                <small class="stat-subtext" id="headline-description">BP relocating its global headquarters to Bankside, leasing</small>
+                <span class="stat-value" id="headline-size">192,000 sq ft</span>
+                <small class="stat-subtext" id="headline-building">at <strong>Ink, Timber Square, SE1</strong></small>
               </div>
             </div>
           </div>
@@ -3510,24 +3510,19 @@
 
       const HEADLINE_EVENTS = [
         {
-          description: 'Visa relocating European headquarters to Canary Wharf, leasing',
-          size: '300,000 sq ft',
-          building: 'One Canada Square, E14'
+          description: 'BP relocating its global headquarters to Bankside, leasing',
+          size: '192,000 sq ft',
+          building: 'Ink, Timber Square, SE1'
         },
         {
-          description: 'HSF Kramer relocating London headquarters within Broadgate, leasing',
-          size: '268,000 sq ft',
-          building: '1 Appold Street, EC2'
+          description: 'Anthropic expanding its London headquarters at Regent\'s Place, leasing',
+          size: '158,000 sq ft',
+          building: 'One Triton Square, NW1'
         },
         {
-          description: 'Quantexa preletting London headquarters space, leasing',
-          size: '52,293 sq ft',
-          building: 'The Delft, SE1'
-        },
-        {
-          description: 'Gibson, Dunn & Crutcher relocating London office, leasing',
-          size: '154,000 sq ft',
-          building: 'One Exchange Square, EC2'
+          description: 'OpenAI taking its first permanent London office, leasing',
+          size: '88,500 sq ft',
+          building: 'Jahn Court & Brassworks, N1'
         }
       ];
 


### PR DESCRIPTION
## Summary

Refresh the `RECENT HEADLINE EVENTS` rotator with three signed, source-backed Central London office transactions from 2026 while preserving the existing occupier/action → size → building format and six-second rotation.

## Updated events

1. **BP** relocating its global headquarters to Bankside — **192,000 sq ft** at **Ink, Timber Square, SE1**
2. **Anthropic** expanding its London headquarters at Regent's Place — **158,000 sq ft** at **One Triton Square, NW1**
3. **OpenAI** taking its first permanent London office — **88,500 sq ft** at **Jahn Court & Brassworks, N1**

The selection combines two Q2 2026 announcements with one exceptionally large late-Q1 global-headquarters letting. It covers Bankside, Regent's Place and King's Cross and reflects both major corporate demand and the rapid growth of AI occupiers in the Central London market.

## Sources

- Landsec, 19 March 2026: [192,000 sq ft BP global HQ letting at Timber Square](https://www.landsec.com/en/media-insights/press-releases/landsec-leases-54-percent-of-timber-square-to-bp)
- British Land, 21 April 2026: [158,000 sq ft Anthropic letting at One Triton Square](https://www.britishland.com/media/l1fl1uzf/bl-260420-q4-trading-update.pdf)
- Endurance Land, April 2026: [88,500 sq ft OpenAI permanent office at Regent Quarter](https://www.enduranceland.com/2026/openai-announces-first-permanent-uk-office-at-regent-quarter/)
- Cross-check: [Cushman & Wakefield Q1 2026 Central London MarketBeat](https://www.cushmanwakefield.com/en-united-kingdom/insights/uk-marketbeat/london-office-marketbeat)
- Cross-check: [Savills April 2026 Central London Office Market Watch](https://281.v3.savills-vx.com/research_articles/244290/390321-0)

## Validation

- confirmed exactly three rotating events and a matching first-item HTML fallback
- verified all descriptions, sizes and buildings against the cited sources
- exercised the full rotation on desktop
- checked wrapping and horizontal overflow at a 390 px phone viewport
- browser console returned no warnings or errors
- reran the Q2 2026 workbook regression check for all 21 landing-page submarkets
- remote GitHub blob hash matches the locally tested file
