### PR TITLE
Open iPhone dashboards in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -1680,7 +1680,8 @@
       }
 
       function shouldUseSameTabNavigation(){
-        return isPhoneView();
+        /* Dashboard pages must escape the nested Infogram iframe on every device. */
+        return false;
       }
 
       function isLinkedInInAppBrowser(){


### PR DESCRIPTION
## Summary

- makes dashboard links use `target="_blank"` on phone as well as desktop
- makes map-initiated dashboard navigation use `window.open(..., "_blank")` on phone
- preserves the existing LinkedIn in-app-browser warning and blocker
- leaves the restored map, table, phone submarket list, Q2 2026 data, and headlines unchanged

## Root cause

The phone-specific navigation helper returned `true`, so table links were rendered with `target="_self"` and map clicks used `window.location.assign()`. Because the tool runs inside an Infogram iframe, this attempted to load the dashboard inside that nested iframe and produced the white screen on iPhone.

## Verification

- branch is one commit ahead of `main`
- changes only `index.html` (2 additions, 1 deletion)
- branch file is otherwise identical to current `main`
- all dashboard paths now resolve to the existing desktop `_blank` behaviour
- LinkedIn detection and browser guidance are untouched